### PR TITLE
Allow skipping cached queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@ Logs the source of execution of all queries to the Rails log. Helpful to track d
 Install
 -------
 
+Install the latest stable release:
+
 `gem install active_record_query_trace`
+
+In Rails, add it to your Gemfile, then restart the server:
+
+```ruby
+gem 'active_record_query_trace'
+```
 
 Usage
 -----
@@ -21,10 +29,16 @@ There are three levels of debug.
 
 1. app - includes only files in your app/ directory.
 2. full - includes files in your app as well as rails.
-3. rails - alternate ouput of full backtrace, useful for debugging gems.
+3. rails - alternate output of full backtrace, useful for debugging gems.
 
 ```ruby
 ActiveRecordQueryTrace.level = :app # default
+```
+
+By default, a backtrace will be logged for every query, even cached queries that do not actually hit the database. You might find it useful not to print the backtrace for cached queries:
+
+```ruby
+ActiveRecordQueryTrace.ignore_cached_queries
 ```
 
 Additionally, if you are working with a large app, you may wish to limit the number of lines displayed for each query.
@@ -40,8 +54,9 @@ When enabled every query source will be logged like:
 
 ```
   IntuitAccount Load (1.2ms)  SELECT "intuit_accounts".* FROM "intuit_accounts" WHERE "intuit_accounts"."user_id" = 20 LIMIT 1
-Called from: app/views/users/edit.html.haml:78:in `block in _app_views_users_edit_html_haml___1953197429694975654_70177901460360'
- app/views/users/edit.html.haml:16:in `_app_views_users_edit_html_haml___1953197429694975654_70177901460360'
+Called from:
+  app/views/users/edit.html.haml:78:in `block in _app_views_users_edit_html_haml___1953197429694975654_70177901460360'
+  app/views/users/edit.html.haml:16:in `_app_views_users_edit_html_haml___1953197429694975654_70177901460360'
 ```
 
 Requirements


### PR DESCRIPTION
I've added a new `:ignore_cached_queries` configuration option to prevent output of the backtrace for cached queries.

This is useful if you are only interested in tracking down the origin of database queries that actually hit the database.

Set this option to `true`... 

```ruby
ActiveRecordQueryTrace.enabled = true
ActiveRecordQueryTrace.ignore_cached_queries = true
```

...and backtrace output will not occur for any SQL query that uses cached results (i.e. those SQL queries that would show up in the log prefixed with `CACHE`).

I'm using this in conjunction with a custom logger in development that also skips logging of cached queries.. In `development.rb`,

```ruby
  # Don't log cached queries
  class LogWithoutCachedQueries < ::Logger
    def debug(message, *args, &block)
      unless message.include? 'CACHE ('
        super
      end
    end
  end

  # Default is 1GB!  Let's limit to 3 5MB files
  max_log_files = 3
  max_log_size = 5 * 1024 * 1024
  log_file = Rails.root.join('log', Rails.env + '.log')

  config.logger = LogWithoutCachedQueries.new(log_file, max_log_files, max_log_size)
```

