### PR TITLE
Clarify that ignore_cached_queries is an accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ActiveRecordQueryTrace.level = :app # default
 By default, a backtrace will be logged for every query, even cached queries that do not actually hit the database. You might find it useful not to print the backtrace for cached queries:
 
 ```ruby
-ActiveRecordQueryTrace.ignore_cached_queries
+ActiveRecordQueryTrace.ignore_cached_queries = true # Default is false.
 ```
 
 Additionally, if you are working with a large app, you may wish to limit the number of lines displayed for each query.


### PR DESCRIPTION
The README otherwise wasn't clear that you had to do `ignore_cached_queries = true` for the setting to be applied.