### PR TITLE
Track queries from 'lib' or 'engines' folders

### DIFF
--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -55,8 +55,12 @@ module ActiveRecordQueryTrace
         case ActiveRecordQueryTrace.level
         when :full
           trace
-        when :rails, :app
+        when :rails
           Rails.respond_to?(:backtrace_cleaner) ? Rails.backtrace_cleaner.clean(trace) : trace
+        when :app
+          Rails.backtrace_cleaner.remove_silencers!
+          Rails.backtrace_cleaner.add_silencer { |line| not line =~ /^(app|lib|engines)\// }
+          Rails.backtrace_cleaner.clean(trace)
         else
           raise "Invalid ActiveRecordQueryTrace.level value '#{ActiveRecordQueryTrace.level}' - should be :full, :rails, or :app"
         end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordQueryTrace
-  VERSION = '1.5'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
With current solution we are not able to track queries executed from lib or engines folders.