### PR TITLE
add full list of included directories for app dubug level

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ActiveRecordQueryTrace.enabled = true
 
 There are three levels of debug.
 
-1. app - includes only files in your app/ directory.
+1. app - includes only files in your app/, lib/, and engines/ directories.
 2. full - includes files in your app as well as rails.
 3. rails - alternate output of full backtrace, useful for debugging gems.
 


### PR DESCRIPTION
Hello,

Cool gem, thank you for it!
There is small inaccuracy in the description.
I had to take a look in source code to get that using debug level `app` gem also logs queries from `lib` and `engines` directories.

I added small change to description to let other people full list of included directories.