### PR TITLE
Enable colorization of output log

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Additionally, if you are working with a large app, you may wish to limit the num
 ActiveRecordQueryTrace.lines = 10 # Default is 5. Setting to 0 includes entire trace.
 ```
 
+If you want the output can be colorized with a string of the color or a code. Valid colors are:
+'black', 'red', 'green', 'brown', 'blue', 'purple', 'cyan',
+'gray', 'dark gray', 'light red', 'light green', 'yellow', 'light blue',
+'light purple', 'light cyan', 'white'
+
+```ruby
+ActiveRecordQueryTrace.colorize = false # No colorization(default)
+ActiveRecordQueryTrace.colorize = 'light purple'
+ActiveRecordQueryTrace.colorize = true # Colorize in default color
+ActiveRecordQueryTrace.colorize = 35 # Magenta
+```
+
+
+
 ## Output
 
 When enabled every query source will be logged like:

--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -8,6 +8,7 @@ module ActiveRecordQueryTrace
     attr_accessor :level
     attr_accessor :lines
     attr_accessor :ignore_cached_queries
+    attr_accessor :colorize
   end
 
   module ActiveRecord
@@ -19,6 +20,7 @@ module ActiveRecordQueryTrace
         ActiveRecordQueryTrace.level = :app
         ActiveRecordQueryTrace.lines = 5
         ActiveRecordQueryTrace.ignore_cached_queries = false
+        ActiveRecordQueryTrace.colorize = false
 
         if ActiveRecordQueryTrace.level != :app
           # Rails by default silences all backtraces that match Rails::BacktraceCleaner::APP_DIRS_PATTERN
@@ -41,8 +43,29 @@ module ActiveRecordQueryTrace
           return if ActiveRecordQueryTrace.ignore_cached_queries && payload[:name] == 'CACHE'
 
           cleaned_trace = clean_trace(caller)[index].join("\n     from ")
-          debug("  Query Trace > " + cleaned_trace) unless cleaned_trace.blank?
+          debug("  Query Trace > " + colorize_text(cleaned_trace)) unless cleaned_trace.blank?
         end
+      end
+
+      # Allow query to be colorized in the terminal
+      def colorize_text(text)
+        return text unless ActiveRecordQueryTrace.colorize
+        # Try to convert the choosen color from string to integer or try
+        # to use the colorize as the color code
+        colors = {
+          true => "38",       "blue" => "34",        "light red" => "1;31",
+          "black" => "30",    "purple" => "35",      "light green" => "1;32",
+          "red" => "31",      "cyan" => "36",        "yellow" => "1;33",
+          "green" => "32",    "gray" => "37",        "light blue" => "1;34",
+          "brown" => "33",    "dark gray" => "1;30", "light purple" => "1;35",
+          "white" => "1;37",  "light cyan" => "1;36"
+        }
+        color_code = colors[ActiveRecordQueryTrace.colorize] ||
+          ActiveRecordQueryTrace.colorize.to_s
+        unless /\d+(;\d+){0,1}/.match(color_code)
+          raise "Invalid color. Use one of #{ colors.keys } or a valid color code"
+        end
+        "\e[#{ color_code }m#{ text }\e[0m"
       end
 
       def clean_trace(trace)


### PR DESCRIPTION
Add configuration option so the users can configure the color of the
output. Valid colors are:

    'black', 'red', 'green', 'brown', 'blue', 'purple', 'cyan', 'gray',
    'dark gray', 'light red', 'light green', 'yellow', 'light blue',
    'light purple', 'light cyan', 'white'

But the user can use the terminal code as number. Examples:

    ActiveRecordQueryTrace.colorize = 'light purple'
    ActiveRecordQueryTrace.colorize = 35 # Magenta