### PR TITLE
Easily access the logger

### DIFF
--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -9,6 +9,14 @@ module ActiveRecordQueryTrace
     attr_accessor :lines
     attr_accessor :ignore_cached_queries
     attr_accessor :colorize
+
+    def logger
+      ActiveRecordQueryTrace::ActiveRecord::LogSubscriber.logger
+    end
+
+    def logger=(new_logger)
+      ActiveRecordQueryTrace::ActiveRecord::LogSubscriber.logger = new_logger
+    end
   end
 
   module ActiveRecord


### PR DESCRIPTION
This is an awesome gem, it's super handy! One thing I find though is when debugging from the console it can be a pain to switch the logger to print to STDOUT instead of the log file. This change provides a more intuitive API for swapping out the log device:

```ruby
ActiveRecordQueryTrace.logger = Logger.new STDOUT
```