### PR TITLE
Readme debug levels were switched

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ ActiveRecordQueryTrace.enabled = true
 There are three levels of debug.
 
 1. app - includes only files in your app/, lib/, and engines/ directories.
-2. full - includes files in your app as well as rails.
-3. rails - alternate output of full backtrace, useful for debugging gems.
+2. rails - includes files in your app as well as rails.
+3. full - alternate output of full backtrace, useful for debugging gems.
 
 ```ruby
 ActiveRecordQueryTrace.level = :app # default


### PR DESCRIPTION
The debug level options for `rails` and `full` were there switched from there descriptions