### PR TITLE
Fix #30 ignore_cached_queries

### DIFF
--- a/lib/active_record_query_trace.rb
+++ b/lib/active_record_query_trace.rb
@@ -48,9 +48,9 @@ module ActiveRecordQueryTrace
 
           payload = event.payload
           return if payload[:name] == 'SCHEMA'
-          return if ActiveRecordQueryTrace.ignore_cached_queries && payload[:name] == 'CACHE'
+          return if ActiveRecordQueryTrace.ignore_cached_queries && payload[:cached]
 
-          cleaned_trace = clean_trace(caller)[index].join("\n     from ")
+          cleaned_trace = clean_trace(caller)[index].join("\n     ")
           debug("  Query Trace > " + colorize_text(cleaned_trace)) unless cleaned_trace.blank?
         end
       end


### PR DESCRIPTION
- Fix #30 - Cache queries are logged even with option to not log them enabled.
- Remove the `from ` string from backtrace lines.
